### PR TITLE
appveyor CI build check

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: 1.0.{build}
+image: Visual Studio 2015
+
+build:
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - yarn outdated
+    - yarn install
+    - cd client
+    - yarn outdated
+    - yarn install
+    #- cd ..
+    - npm test
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "npppm",
   "version": "3.0.0",
+  "license": "MIT",
   "scripts": {
     "start": "nodemon server/index.js",
     "start-db": "docker run -d --name npppm-couchdb -e NODENAME=single -p 5985:5984 -v $(pwd)/couchdb-data:/opt/couchdb/data klaemo/couchdb && scripts/initialise-couchdb.sh localhost:5985",


### PR DESCRIPTION
- initial test version of appveyor.yml
- add missing license info for the server, added same as client
- see #17 

- see https://ci.appveyor.com/project/chcg/npppm3/build/1.0.5, just client npm test added, as server fails already at init (https://ci.appveyor.com/project/chcg/npppm3/build/1.0.4). Also parts of the client tests fail, which is not the case within my local run, maybe some dependency.

- a travis CI build might make sense to test this one linux with a proper installation environment
- What about these warnings?

```
warning "react-tooltip@3.2.6" has unmet peer dependency "react@^0.14.0 || ^15.0.0".
warning "react-tooltip@3.2.6" has unmet peer dependency "react-dom@^0.14.0 || ^15.0.0".
[4/4] Building fresh packages...
```
```
warning fsevents@1.0.15: The platform "win32" is incompatible with this module.
info "fsevents@1.0.15" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
```
Could they be avoided? Do they have any influence on the output?

